### PR TITLE
Handle enrollment lookup type mismatches

### DIFF
--- a/modules/experiments_v2.py
+++ b/modules/experiments_v2.py
@@ -9,6 +9,7 @@ import igraph as ig
 
 import numpy as np
 import pandas as pd
+import warnings
 
 from config.config import Config
 cf = Config()
@@ -165,12 +166,26 @@ class Experiments:
     def _transfer_enrollment(self, es_node, jhs_idx, enrollment_df, graph):
         """Move Grade 6 enrollment from ES node to a JHS vertex."""
         es_id = es_node['school_id']
+
+        # Ensure the lookup uses the same type as the enrollment DataFrame index
+        if len(enrollment_df.index) > 0:
+            index_example = enrollment_df.index[0]
+            try:
+                es_id_lookup = type(index_example)(es_id)
+            except (ValueError, TypeError):
+                es_id_lookup = es_id
+        else:
+            es_id_lookup = es_id
+
         try:
-            g6 = enrollment_df.loc[es_id, 'enr_grade_6']
+            g6 = enrollment_df.loc[es_id_lookup, 'enr_grade_6']
         except KeyError:
+            warnings.warn(
+                f"School ID {es_id} not found in enrollment data", RuntimeWarning
+            )
             return
         if g6 > 0 and not math.isnan(g6):
-            enrollment_df.loc[es_id, 'enr_grade_6'] -= g6
+            enrollment_df.loc[es_id_lookup, 'enr_grade_6'] -= g6
             graph.vs[jhs_idx]['school_attrs'][0]['enrollment_jhs'] += g6
 
     def _compute_mean_congestion(self, graph, jhs_cocs):


### PR DESCRIPTION
## Summary
- Ensure ES school IDs use the same type as the enrollment DataFrame index
- Warn when an ES school ID is missing from enrollment data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c10e4973f0832fa794624e96e084ce